### PR TITLE
Bugfix no pull binding option

### DIFF
--- a/HodorReflexes.addon
+++ b/HodorReflexes.addon
@@ -60,7 +60,7 @@ modules/vote/main.lua
 modules/vote/menu.lua
 modules/vote/ui.xml
 modules/pull/main.lua
-modules/pull/bindings.lua
+modules/pull/bindings.xml
 modules/exitinstance/main.lua
 modules/exitinstance/bindings.xml
 


### PR DESCRIPTION
There is a small error in the HodorReflex.addon file, modules/pull/bindings.lua -> modules/pull/bindings.xml, otherwise there is no option displayed to bind a key to the pull command.

