### PR TITLE
Idea of HodorReflexes-lite

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,11 +34,11 @@ jobs:
           addon_name="HodorReflexes"
           version="${{ env.BUILD_DATE_WITH_HYPHEN }}-dev"
           
-          zip_name="${addon_name}-${version}.zip"
-          
           echo "ADDON_NAME=$addon_name" >> $GITHUB_ENV
           echo "ADDON_VERSION=$version" >> $GITHUB_ENV
-          echo "ZIP_FULL_NAME=$zip_name" >> $GITHUB_ENV
+          
+          echo "ZIP_FULL_NAME=${addon_name}-${version}.zip" >> $GITHUB_ENV
+          echo "ZIP_LITE_NAME=${addon_name}-${version}-lite.zip" >> $GITHUB_ENV
 
       - name: Replace placeholders with current date
         run: |
@@ -63,6 +63,14 @@ jobs:
           
           # Make full version zip
           (cd /tmp && zip -r --quiet "$REPO_FOLDER/${{ env.ZIP_FULL_NAME }}" "${{ env.ADDON_NAME }}")
+          
+          # Make lite version. Remove custom users icons
+          rm -rf $TMP_FOLDER/users
+          sed -i '/^users\//d' $TMP_FOLDER/${{ env.ADDON_NAME }}.addon
+          sed -i "s/liteVersion = false/liteVersion = true/g" $TMP_FOLDER/${{ env.ADDON_NAME }}.lua
+          
+          # Make lite version zip
+          (cd /tmp && zip -r --quiet "$REPO_FOLDER/${{ env.ZIP_LITE_NAME }}" "${{ env.ADDON_NAME }}")
 
       - name: Extract latest changelog entry
         run: |
@@ -75,7 +83,7 @@ jobs:
           name: "${{ env.ADDON_VERSION }}"
           commit: ${{ github.ref }}
           tag: "${{ env.ADDON_VERSION }}"
-          artifacts: "${{ env.ZIP_FULL_NAME }}"
+          artifacts: "${{ env.ZIP_FULL_NAME }}, ${{ env.ZIP_LITE_NAME }}"
           artifactContentType: application/zip
           bodyFile: latest_changes.md
           allowUpdates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
           addon_name="HodorReflexes"
           version="${{ env.BUILD_DATE_WITH_HYPHEN }}"
           
-          zip_name="${addon_name}-${version}.zip"
-          
           echo "ADDON_NAME=$addon_name" >> $GITHUB_ENV
           echo "ADDON_VERSION=$version" >> $GITHUB_ENV
-          echo "ZIP_FULL_NAME=$zip_name" >> $GITHUB_ENV
+          
+          echo "ZIP_FULL_NAME=${addon_name}-${version}.zip" >> $GITHUB_ENV
+          echo "ZIP_LITE_NAME=${addon_name}-${version}-lite.zip" >> $GITHUB_ENV
 
       - name: Replace placeholders with current date
         run: |
@@ -65,6 +65,14 @@ jobs:
           
           # Make full version zip
           (cd /tmp && zip -r --quiet "$REPO_FOLDER/${{ env.ZIP_FULL_NAME }}" "${{ env.ADDON_NAME }}")
+          
+          # Make lite version. Remove custom users icons
+          rm -rf $TMP_FOLDER/users
+          sed -i '/^users\//d' $TMP_FOLDER/${{ env.ADDON_NAME }}.addon
+          sed -i "s/liteVersion = false/liteVersion = true/g" $TMP_FOLDER/${{ env.ADDON_NAME }}.lua
+          
+          # Make lite version zip
+          (cd /tmp && zip -r --quiet "$REPO_FOLDER/${{ env.ZIP_LITE_NAME }}" "${{ env.ADDON_NAME }}")
 
       - name: Extract latest changelog entry
         run: |
@@ -77,7 +85,7 @@ jobs:
           name: "${{ env.ADDON_VERSION }}"
           commit: ${{ github.ref }}
           tag: "${{ env.ADDON_VERSION }}"
-          artifacts: "${{ env.ZIP_FULL_NAME }}"
+          artifacts: "${{ env.ZIP_FULL_NAME }}, ${{ env.ZIP_LITE_NAME }}"
           artifactContentType: application/zip
           bodyFile: latest_changes.md
           allowUpdates: true

--- a/HodorReflexes.lua
+++ b/HodorReflexes.lua
@@ -30,6 +30,8 @@ HodorReflexes = {
 	name = "HodorReflexes",
 	version = "dev",
 
+	liteVersion = false,
+
 	-- Default settings for saved variables
 	default = {
 		confirmExitInstance = true,                -- Show confirmation dialog before exiting instances

--- a/modules/share/main.lua
+++ b/modules/share/main.lua
@@ -388,6 +388,11 @@ end
 --- Additionally, it displays a version update window and notifies the player if any icons are missing.
 
 local function initializeUpdateIcons()
+	if HR.liteVersion then
+		-- d("Using Lite Version. No user icons loaded")
+		return
+	end
+
 	--- List of texture controls to be updated with icons, excluding the player's icon.
 	local updatedTextureControls = {
 		HodorReflexes_Updated_Icon4,


### PR DESCRIPTION
First of all, thank you for your hard work and the great addon.

At the moment, custom user icons weigh 15 MB (~60 MB unpacked), and the addon itself is about 150 KB.
I want to suggest the idea of a lite version of the addon without custom icons.

In fact, I've been using it for some time now, and now the idea has matured that you can build two versions of the addon at once using github actions.

If desired, you can create a second version on ESOUI and post both addons there. In this matter, I do not know what is the best way to proceed.

Release example in my fork 
https://github.com/NeBioNik/HodorReflexesLite/releases/tag/2025-04-14

[HodorReflexes-2025-04-14-lite.zip](https://github.com/user-attachments/files/19737505/HodorReflexes-2025-04-14-lite.zip)
