### PR TITLE
Do not show Icons module for HRLite

### DIFF
--- a/modules/share/main.lua
+++ b/modules/share/main.lua
@@ -703,7 +703,9 @@ function M.Initialize()
 
 	-- Build settings menus
 	M.BuildMenu()
-	M.BuildIconsMenu()
+	if not HR.liteVersion then
+		M.BuildIconsMenu()
+	end
 	M.BuildStyleMenu()
 
 	-- Create scene fragments for controls


### PR DESCRIPTION
Continuing from the previous PR #16 discussion, I've found one place where we should handle HRLite specifically by disabling the icons menu. 

From what I can tell, even if custom icons are enabled in settings but don't physically exist, the rendering should automatically fall back to `defaultIcon` without requiring additional fixes. The current implementation seems to handle this gracefully.

However, if you think it's necessary, we could add explicit HRLite checks to lines like:
```lua
SetControlIcon(ultRow:GetNamedChild('_Icon'), SW.enableUltimateIcons and userIcon or defaultIcon)

-- something like this
SetControlIcon(ultRow:GetNamedChild('_Icon'), SW.enableUltimateIcons and HR.liteVersion and userIcon or defaultIcon)
```

If there are other places in the codebase that need similar adjustments for the lite version, please let me know where they are. I'm happy to implement those changes as well to ensure proper separation between the full and lite versions.
