### PR TITLE
fix cryptcanon amount for group members

### DIFF
--- a/modules/ult/list_compact.lua
+++ b/modules/ult/list_compact.lua
@@ -328,7 +328,7 @@ function module:compactListCryptCannonRowCreationFunction(rowControl, data, scro
     rowControl:GetNamedChild('_BG'):SetAlpha(self.compactList.sw.backgroundAlpha)
     rowControl:GetNamedChild("_UltIcon"):SetTexture(self.cryptCannonIcon)
 
-    local groupSize = GetGroupSize()
+    local groupSize = zo_max(GetGroupSize() - 1, 0) -- ultimate is transferred to everyone except the wearer
     if groupSize == 0 then -- when in test mode, we use the number of players in the data table so we do not divide by 0 while calculating the shared ult
         for _, _ in pairs(addon.playersData) do
             groupSize = groupSize + 1


### PR DESCRIPTION
The current implementation of cryptcanon in the compact list creates an incorrect value.

It should be that in the situation where two people are grouped, using a full cryptcanon replenishes the ultimate of the other player entirely.

However, the existing implementation shows only 250 ultimate on the list, because the group size is two. 

This PR fixes this to be accurate, by removing one from the group size and saturating at the zero boundary.