### PR TITLE
Show configurator extention if any lib exists

### DIFF
--- a/extensions/configurator/PC/main.lua
+++ b/extensions/configurator/PC/main.lua
@@ -40,7 +40,7 @@ local extension = internal.extensionClass:New(extensionDefinition)
 --- NOT for manual use. This function gets called once when the extension is loaded and then deleted afterwards.
 --- @return void
 function extension:Activate()
-    if not LCN and not LCI then
+    if not LCN then
         self.enabled = false
         return
     end


### PR DESCRIPTION
<img width="950" height="510" alt="image" src="https://github.com/user-attachments/assets/736a701b-0b02-4bed-b9d5-12e4498aad59" />
If LCN is installed but LCI is not, there is no configurator.

Fixed this.