### PR TITLE
Added LibRadialMenu as an optional dependancy for PC

### DIFF
--- a/HodorReflexes.addon
+++ b/HodorReflexes.addon
@@ -10,7 +10,7 @@
 ## DependsOn: LibGroupCombatStats>=20250816 LibGroupBroadcast>=91 LibDebugLogger>=268
 ## PCDependsOn: LibAddonMenu-2.0>=40 LibCombat>=84
 ## ConsoleDependsOn: LibHarvensAddonSettings>=20004 LibCombat2>=8 LibRadialMenu>=1
-## OptionalDependsOn: LibCombat2>=8 LibCustomNames>=1 LibCustomIcons>=1
+## OptionalDependsOn: LibCombat2>=8 LibCustomNames>=1 LibCustomIcons>=1 LibRadialMenu>=1
 
 ; This Add-on is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates.
 ; The Elder Scrolls® and related logos are registered trademarks or trademarks of ZeniMax Media Inc. in the United States and/or other countries.
@@ -37,6 +37,7 @@ core/donate.lua
 core/menu.lua
 core/PC/menu.lua
 core/PC/LibCheck.lua
+core/PC/LibRadialMenu.lua
 core/PC/donate.lua
 core/Console/menu.lua
 core/Console/LibCheck.lua

--- a/core/PC/LibRadialMenu.lua
+++ b/core/PC/LibRadialMenu.lua
@@ -1,0 +1,8 @@
+-- SPDX-FileCopyrightText: 2025 m00nyONE
+-- SPDX-License-Identifier: Artistic-2.0
+local addon_name = "HodorReflexes"
+
+local LRM = LibRadialMenu
+if LRM then
+	LRM:RegisterAddon(addon_name, addon_name)
+end

--- a/modules/exitinstance/PC/bindings.lua
+++ b/modules/exitinstance/PC/bindings.lua
@@ -14,6 +14,9 @@ local module = addon_modules[module_name]
 
 local localPlayer = "player"
 
+local LRM = LibRadialMenu
+local texture = "/esoui/art/menubar/gamepad/gp_playermenu_icon_logout.dds"
+
 --- Setup keybinds for Exit Instance module
 --- @return void
 function module:SetupKeybinds()
@@ -37,5 +40,12 @@ function module:SetupKeybinds()
     end
     if GAMEPAD_GROUP_SCENE then
         GAMEPAD_GROUP_SCENE:RegisterCallback("StateChange", OnStateChanged)
+    end
+
+    local function SendExitInstanceRequestWrapper()
+        module:SendExitInstanceRequest()
+    end
+    if LRM then
+        LRM:RegisterEntry(addon_name, "Send Exit Instance Request", "Send Exit Instance Request", texture, SendExitInstanceRequestWrapper, GetString(HR_MODULES_EXITINSTANCE_COMMAND_HELP))
     end
 end

--- a/modules/pull/PC/bindings.lua
+++ b/modules/pull/PC/bindings.lua
@@ -14,6 +14,9 @@ local module = addon_modules[module_name]
 
 local localPlayer = "player"
 
+local LRM = LibRadialMenu
+local texture = "EsoUI/Art/HUD/HUD_Countdown_Badge_Dueling.dds"
+
 --- Keybind button for sending pull countdown
 --- @return void
 function module:SetupKeybinds()
@@ -42,5 +45,12 @@ function module:SetupKeybinds()
     end
     if GAMEPAD_GROUP_SCENE then
         GAMEPAD_GROUP_SCENE:RegisterCallback("StateChange", OnStateChanged)
+    end
+
+    local function sendPullCountdownWrapper()
+        module:SendPullCountdown()
+    end
+    if LRM then
+        LRM:RegisterEntry(addon_name, "Pull countdown", "pull countdown", texture, sendPullCountdownWrapper, GetString(HR_MODULES_PULL_COMMAND_HELP))
     end
 end


### PR DESCRIPTION
Added a libradialmenu optional dependency for pc, similar to console.
Actions added: Exit Instance, Pull countdown. Functions the same as on console.